### PR TITLE
Very small readme typo

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -69,7 +69,7 @@ This includes making it line up with all alignment zones for similar height
 symbol characters and fixing Menlo's absence of a slanting angle for the italic 
 and bold italic font styles while maintaining the readability at all sizes.
 
-v1.0
+v1.1
 
 Added a dotted zero version of Meslo LG which is called Meslo LG DZ.
 


### PR DESCRIPTION
You say V1.0, V1.0, and then V1.2, skipping over V1.1 (when the dotted zero versions were added).
This is just a small fix for that.
